### PR TITLE
🔗 Added Link to Official MIT License Text in Readme File

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ If you want to contribute to this project, feel free to fork the repository and 
 
 ### License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. For more details, see the full [MIT License text](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Hey im-ashar! 👋

I noticed that the README file mentioned that the `LICENSE` file contains the details, but it didn't include a direct link to the official `MIT License` text. To make it easier for users to access the full terms of the license, I’ve added a link. This change is reflected in the Readme.

Looking forward to your feedback! Thanks! 🙌